### PR TITLE
Add support for XML reports

### DIFF
--- a/src/Core/DrivenMetrics.csproj
+++ b/src/Core/DrivenMetrics.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Metrics\ILCyclomicComplextityCalculator.cs" />
     <Compile Include="Metrics\IMetricCalculator.cs" />
     <Compile Include="Metrics\NumberOfLinesCalculator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reporting\FileWriter.cs" />
     <Compile Include="Reporting\HtmlReport.cs" />
     <Compile Include="Reporting\HtmlTopTenReport.cs" />
@@ -83,9 +84,6 @@
       <Project>{2D970FBC-977C-4B5E-B347-2DF0F92E3BEC}</Project>
       <Name>Mono.Cecil.Extensions</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Core/DrivenMetrics.csproj
+++ b/src/Core/DrivenMetrics.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,7 +8,7 @@
     <ProjectGuid>{E25161E9-6DEF-400D-9882-B99D8A7C36C8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DrivenMetrics</RootNamespace>
+    <RootNamespace>Driven.Metrics</RootNamespace>
     <AssemblyName>DrivenMetrics</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -76,6 +76,7 @@
     <Compile Include="Reporting\HtmlFailedReport.cs" />
     <Compile Include="Reporting\ReportType.cs" />
     <Compile Include="Reporting\ReportFactory.cs" />
+    <Compile Include="Reporting\XmlReport.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mono.Cecil.Extensions\Mono.Cecil.Extensions.csproj">

--- a/src/Core/Metrics/MetricResult.cs
+++ b/src/Core/Metrics/MetricResult.cs
@@ -20,9 +20,9 @@ namespace Driven.Metrics.Metrics
     public class ClassResult
     {
         public string Name {get; private set;}
-        public List<MethodResult> MethodResults {get; private set;}
+        public IList<MethodResult> MethodResults {get; private set;}
 		
-        public ClassResult(string name, List<MethodResult> methodResults)
+        public ClassResult(string name, IList<MethodResult> methodResults)
         {
             Name = name;
             MethodResults = methodResults; 
@@ -33,9 +33,9 @@ namespace Driven.Metrics.Metrics
     public class MetricResult
     {
         public string Name {get; private set;}
-        public List<ClassResult> ClassResults {get; private set;}
+        public IList<ClassResult> ClassResults {get; private set;}
 		
-        public MetricResult(string name, List<ClassResult> classResults)
+        public MetricResult(string name, IList<ClassResult> classResults)
         {
             Name = name;
             ClassResults = classResults;

--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DrivenMetrics.Tests")]

--- a/src/Core/Reporting/ReportFactory.cs
+++ b/src/Core/Reporting/ReportFactory.cs
@@ -12,7 +12,9 @@ namespace Driven.Metrics.Reporting
 				report = new HtmlFailedReport(fileWriter, reportName);
             else if (reportType == ReportType.TopTen)
                 report = new HtmlTopTenReport(fileWriter, reportName);
-			else
+            else if (reportName.EndsWith (".xml"))
+                report = new XmlReport (fileWriter, reportName);
+            else
 				report = new HtmlReport(fileWriter,reportName);
 			
 			return report;

--- a/src/Core/Reporting/XmlReport.cs
+++ b/src/Core/Reporting/XmlReport.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using Driven.Metrics.Metrics;
+
+namespace Driven.Metrics.Reporting
+{
+    public class XmlReport : IReport
+    {
+        #region IReport Members
+
+        public void Generate (IEnumerable<MetricResult> results)
+        {
+            throw new NotImplementedException ();
+        }
+
+        public void Generate (MetricResult result)
+        {
+            throw new NotImplementedException ();
+        }
+
+        #endregion
+    }
+}

--- a/src/Core/Reporting/XmlReport.cs
+++ b/src/Core/Reporting/XmlReport.cs
@@ -1,21 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
 using Driven.Metrics.Metrics;
 
 namespace Driven.Metrics.Reporting
 {
     public class XmlReport : IReport
     {
+        private static readonly XmlWriterSettings XmlWriterSettings = new XmlWriterSettings
+        {
+            NewLineChars = "\n",
+            Indent = true,
+            IndentChars = "  ",
+            OmitXmlDeclaration = true,
+        };
+
+        private readonly IFileWriter _fileWriter;
+        private readonly string _filePath;
+        private readonly XDocument _doc;
+
+        public XmlReport(IFileWriter fileWriter, string filePath)
+        {
+            _fileWriter = fileWriter;
+            _filePath = filePath;
+            _doc = new XDocument(new XElement("metrics"));
+        }
+
+        public override string ToString ()
+        {
+            var sb = new StringBuilder ();
+            using (var writer = XmlWriter.Create (sb, XmlWriterSettings))
+            {
+                Debug.Assert (writer != null);
+                _doc.WriteTo (writer);
+            }
+            return sb.ToString ();
+        }
+
         #region IReport Members
 
         public void Generate (IEnumerable<MetricResult> results)
         {
-            throw new NotImplementedException ();
+            // TODO: convert results to nodes and add them to _doc
+            var contents = ToString ();
+            _fileWriter.Write (_filePath, contents);
         }
 
         public void Generate (MetricResult result)
         {
-            throw new NotImplementedException ();
+            Generate (new [] { result});
         }
 
         #endregion

--- a/src/DrivenMetrics.Tests/DrivenMetrics.Tests.csproj
+++ b/src/DrivenMetrics.Tests/DrivenMetrics.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,7 +8,7 @@
     <ProjectGuid>{56DA1F04-E691-46E9-8823-2EA5B3CF2A28}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DrivenMetrics.Tests</RootNamespace>
+    <RootNamespace>Driven.Metrics.Tests</RootNamespace>
     <AssemblyName>DrivenMetrics.Tests</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -78,6 +78,7 @@
     <Compile Include="Core\Metrics\NumberOfLinesCalculatorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reporting\HtmlReportTest.cs" />
+    <Compile Include="Reporting\XmlReportTest.cs" />
     <Compile Include="TestBuilders\MetricResultBuilder.cs" />
     <Compile Include="TestBuilders\TypeDefinitionBuilder.cs" />
     <Compile Include="TestBuilders\TypeDefinitionListBuilder.cs" />

--- a/src/DrivenMetrics.Tests/DrivenMetrics.Tests.csproj
+++ b/src/DrivenMetrics.Tests/DrivenMetrics.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Core\Metrics\NumberOfLinesCalculatorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reporting\HtmlReportTest.cs" />
+    <Compile Include="Reporting\MemoryFileWriter.cs" />
     <Compile Include="Reporting\XmlReportTest.cs" />
     <Compile Include="TestBuilders\MetricResultBuilder.cs" />
     <Compile Include="TestBuilders\TypeDefinitionBuilder.cs" />

--- a/src/DrivenMetrics.Tests/Reporting/MemoryFileWriter.cs
+++ b/src/DrivenMetrics.Tests/Reporting/MemoryFileWriter.cs
@@ -1,0 +1,20 @@
+﻿using Driven.Metrics.Reporting;
+
+namespace Driven.Metrics.Tests.Reporting
+{
+    internal class MemoryFileWriter : IFileWriter
+    {
+        public string FilePath { get; private set; }
+        public string Contents { get; private set; }
+
+        #region IFileWriter Members
+
+        public void Write (string filepath, string contents)
+        {
+            FilePath = filepath;
+            Contents = contents;
+        }
+
+        #endregion
+    }
+}

--- a/src/DrivenMetrics.Tests/Reporting/XmlReportTest.cs
+++ b/src/DrivenMetrics.Tests/Reporting/XmlReportTest.cs
@@ -1,0 +1,23 @@
+﻿using System.Xml.Linq;
+using Driven.Metrics.Reporting;
+using NUnit.Framework;
+
+namespace Driven.Metrics.Tests.Reporting
+{
+    [TestFixture]
+    public class XmlReportTest
+    {
+        private static void AssertAreEqual(string expectedXml, XmlReport actualReport)
+        {
+            var expectedElement = XElement.Parse (expectedXml);
+            Assert.AreEqual (expectedElement.ToString (), actualReport.ToString ());
+        }
+
+        [Test]
+        public void EmptyReport()
+        {
+            var report = new XmlReport (null, null);
+            AssertAreEqual ("<metrics />", report);
+        }
+    }
+}

--- a/src/DrivenMetrics.Tests/Reporting/XmlReportTest.cs
+++ b/src/DrivenMetrics.Tests/Reporting/XmlReportTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml.Linq;
+using Driven.Metrics.Metrics;
 using Driven.Metrics.Reporting;
 using NUnit.Framework;
 
@@ -18,6 +19,22 @@ namespace Driven.Metrics.Tests.Reporting
         {
             var report = new XmlReport (null, null);
             AssertAreEqual ("<metrics />", report);
+        }
+
+        [Test]
+        public void GenerateNoResults()
+        {
+            // arrange
+            var writer = new MemoryFileWriter ();
+            const string filePath = "<memory>";
+            var report = new XmlReport (writer, filePath);
+
+            // act
+            report.Generate (new MetricResult[] { });
+
+            // assert
+            Assert.AreEqual ("<metrics />", writer.Contents);
+            Assert.AreEqual (filePath, writer.FilePath);
         }
     }
 }

--- a/src/DrivenMetrics.Tests/Reporting/XmlReportTest.cs
+++ b/src/DrivenMetrics.Tests/Reporting/XmlReportTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Xml.Linq;
 using Driven.Metrics.Metrics;
 using Driven.Metrics.Reporting;
+using Driven.Metrics.Tests.TestBuilders;
 using NUnit.Framework;
 
 namespace Driven.Metrics.Tests.Reporting
@@ -35,6 +36,51 @@ namespace Driven.Metrics.Tests.Reporting
             // assert
             Assert.AreEqual ("<metrics />", writer.Contents);
             Assert.AreEqual (filePath, writer.FilePath);
+        }
+
+        [Test]
+        public void ConvertSimpleMethodResult()
+        {
+            var methodResult = new MethodResult ("ConvertResult", 12, true);
+            var actual = XmlReport.ConvertResult (methodResult);
+            Assert.AreEqual (@"<method name=""ConvertResult"" pass=""true"" result=""12"" />", actual.ToString ());
+        }
+
+        [Test]
+        public void ConvertEmptyClassResult()
+        {
+            var classResult = new ClassResult ("XmlReport", new MethodResult[] {});
+            var actual = XmlReport.ConvertResult (classResult);
+            Assert.AreEqual (@"<class name=""XmlReport"" />", actual.ToString ());
+        }
+
+        [Test]
+        public void ConvertEmptyMetricResult ()
+        {
+            var metricResult = new MetricResult ("Cyclomatic Complexity", new ClassResult[] { });
+            var actual = XmlReport.ConvertResult (metricResult);
+            Assert.AreEqual (@"<metric name=""Cyclomatic Complexity"" />", actual.ToString ());
+        }
+
+        [Test]
+        public void GenerateSampleMetricResult()
+        {
+            var instance = new XmlReport (new MemoryFileWriter (), null);
+            var sampleMetricResult = new MetricResultBuilder ().CreateMetricResult ();
+            instance.Generate (sampleMetricResult);
+            AssertAreEqual (@"
+<metrics>
+    <metric name=""Test Metric"">
+        <class name=""Test Class 1"">
+            <method name=""Test Method1"" pass=""false"" result=""12"" />
+            <method name=""Test Method2"" pass=""true"" result=""5"" />
+        </class>
+        <class name=""Test Class 1"">
+            <method name=""Test Method1"" pass=""false"" result=""12"" />
+            <method name=""Test Method2"" pass=""true"" result=""5"" />
+        </class>
+    </metric>
+</metrics>", instance);
         }
     }
 }


### PR DESCRIPTION
With these changes, it is now possible to invoke the tool as follows (notice the report file extension):

```
DrivenMetric.UI.Console.exe -a DrivenMetrics.dll --cc=9 --loc=40 -rAll DrivenMetrics.xml
```

...and get something that looks like:

```
<metrics>
  <metric name="Cyclomic Complexity">
    <class name="HtmlReport">
      <method name="Generate" pass="true" result="5" />
      <method name="Generate" pass="true" result="1" />
      <method name="convertResultToHtml" pass="true" result="1" />
      <method name="inputResults" pass="true" result="9" />
      <method name="createEndOfTable" pass="true" result="1" />
      <method name="createTableHeader" pass="true" result="1" />
      <method name="endOfTable" pass="true" result="2" />
      <method name="addResult" pass="true" result="4" />
      <method name="addHtmlHeader" pass="true" result="1" />
      <method name="addHtmlTail" pass="true" result="1" />
    </class>
    (...)
    <class name="XmlReport">
      <method name="ToString" pass="true" result="4" />
      <method name="ConvertResult" pass="true" result="6" />
      <method name="ConvertResult" pass="true" result="6" />
      <method name="ConvertResult" pass="true" result="2" />
      <method name="Generate" pass="true" result="5" />
      <method name="Generate" pass="true" result="1" />
    </class>
  </metric>
  <metric name="Number Of Lines Of Code">
    <class name="HtmlReport">
      <method name="Generate" pass="true" result="6" />
      <method name="Generate" pass="true" result="1" />
      <method name="convertResultToHtml" pass="true" result="3" />
      <method name="inputResults" pass="true" result="7" />
      <method name="createEndOfTable" pass="true" result="1" />
      <method name="createTableHeader" pass="true" result="2" />
      <method name="endOfTable" pass="true" result="2" />
      <method name="addResult" pass="true" result="10" />
      <method name="addHtmlHeader" pass="true" result="2" />
      <method name="addHtmlTail" pass="true" result="1" />
    </class>
    (...)
    <class name="XmlReport">
      <method name="ToString" pass="true" result="7" />
      <method name="ConvertResult" pass="true" result="7" />
      <method name="ConvertResult" pass="true" result="7" />
      <method name="ConvertResult" pass="true" result="3" />
      <method name="Generate" pass="true" result="8" />
      <method name="Generate" pass="true" result="1" />
    </class>
  </metric>
</metrics>
```

I don't believe it is necessary to implement the XmlFailedReport nor the XmlTopTenReport since it's very easy to obtain those from the XML with the appropriate XPath expression and XSL transform, which would be, respectively:

```
//method[@pass='false']
```

and

```
<?xml version="1.0" encoding="UTF-8"?>
<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">

    <xsl:output method="xml" encoding="UTF-8" indent="yes" />

    <xsl:template match="/metrics">
        <metrics>
            <xsl:for-each select="metric">
                <metric name="{@name}">
                    <xsl:for-each select="current()//method">
                        <xsl:sort select="@result" order="descending" data-type="number" />
                         <xsl:if test="position() &lt; 10">
                            <result class="{parent::class/@name}" method="{@name}" result="{@result}" pass="{@pass}" />
                        </xsl:if>
                    </xsl:for-each>
                </metric>
            </xsl:for-each>
        </metrics>
    </xsl:template>
</xsl:stylesheet>
```

Let me know if you would like me to change anything and/or add more tests.
